### PR TITLE
Fixed location for non-geo searched

### DIFF
--- a/src/tools/api.js
+++ b/src/tools/api.js
@@ -71,7 +71,7 @@ async function callForSearch({ query, client }) {
         // "url": "/Attraction_Review-g188112-d10180843-Reviews-Marktgasse-Winterthur.html",
         // IMPORTANT! HOTELS_URL, ATTRACTIONS_URL, RESTAURANTS_URL leads to 404 error
         // proof: "HOTELS_URL": "/Hotels?geo=10180843",
-        const geoId = location?.details?.url?.split('-g')?.pop()?.split('=')?.shift();
+        const geoId = location?.details?.url?.split('-g')?.pop()?.split('-')?.shift();
         if (geoId && parseInt(geoId, 10)) {
             locationId = parseInt(geoId, 10);
             log.info(`Resolved GeoId ${geoId} from location`, location);

--- a/src/tools/api.js
+++ b/src/tools/api.js
@@ -67,7 +67,22 @@ async function callForSearch({ query, client }) {
     // eslint-disable-next-line no-underscore-dangle
     const isGeo = location?.details?.isGeo;
     if (!isGeo) {
-        log.warning(`Try wider search, current one limited because ${locationId} IS ${location?.details?.placeType}, NOT geolocation`);
+        // for non-geo locations we expecting at least one of the following links with ?geo= parameter
+        const geoLinks = [location?.HOTELS_URL, location?.ATTRACTIONS_URL, location?.RESTAURANTS_URL];
+        /*
+            "url": "/Attraction_Review-g188112-d10180843-Reviews-Marktgasse-Winterthur.html",
+            "HOTELS_URL": "/Hotels?geo=10180843",
+            "ATTRACTIONS_URL": "/Attractions?geo=10180843",
+            "RESTAURANTS_URL": "/Restaurants?geo=10180843",
+            "placeType": "ATTRACTION",
+        */
+        const geoId = geoLinks.find((x) => x.includes('geo='))?.split('geo=')?.[1];
+        if (geoId && parseInt(geoId, 10)) {
+            locationId = parseInt(geoId, 10);
+            log.info(`Resolved GeoId ${geoId} from location`, location);
+        } else {
+            log.warning(`Try wider search, current one limited because ${locationId} IS ${location?.details?.placeType}, NOT geolocation`);
+        }
     }
 
     try {

--- a/src/tools/api.js
+++ b/src/tools/api.js
@@ -67,16 +67,11 @@ async function callForSearch({ query, client }) {
     // eslint-disable-next-line no-underscore-dangle
     const isGeo = location?.details?.isGeo;
     if (!isGeo) {
-        // for non-geo locations we expecting at least one of the following links with ?geo= parameter
-        const geoLinks = [location?.HOTELS_URL, location?.ATTRACTIONS_URL, location?.RESTAURANTS_URL];
-        /*
-            "url": "/Attraction_Review-g188112-d10180843-Reviews-Marktgasse-Winterthur.html",
-            "HOTELS_URL": "/Hotels?geo=10180843",
-            "ATTRACTIONS_URL": "/Attractions?geo=10180843",
-            "RESTAURANTS_URL": "/Restaurants?geo=10180843",
-            "placeType": "ATTRACTION",
-        */
-        const geoId = geoLinks.find((x) => x.includes('geo='))?.split('geo=')?.[1];
+        // for non-geo locations we expecting location from url
+        // "url": "/Attraction_Review-g188112-d10180843-Reviews-Marktgasse-Winterthur.html",
+        // IMPORTANT! HOTELS_URL, ATTRACTIONS_URL, RESTAURANTS_URL leads to 404 error
+        // proof: "HOTELS_URL": "/Hotels?geo=10180843",
+        const geoId = location?.details?.url?.split('-g')?.pop()?.split('=')?.shift();
         if (geoId && parseInt(geoId, 10)) {
             locationId = parseInt(geoId, 10);
             log.info(`Resolved GeoId ${geoId} from location`, location);


### PR DESCRIPTION
Some searches i.e. `Marktgasse 72, 8400 Winterthur, Switzerland` return `locationId` of the places (point of interest like entertainment place or hotel etc. instead of area), so output is a single result, see run under current version: https://console.apify.com/view/runs/ZNAz1Vrs7rJ0QlrTy
Its logically wrong and when we not getting geolocation from search we need to reparse place and use geo ID as `locationId`, see fixed run: https://console.apify.com/view/runs/DOIb0PzV7QxsMTkWr